### PR TITLE
Fix seemingly everything related to bosses

### DIFF
--- a/src/components/Zones.jsx
+++ b/src/components/Zones.jsx
@@ -11,36 +11,18 @@ export default function Zones({
   monsterZone,
   setMonsterZone,
 }) {
-  const [monsterCount, setMonsterCount] = useState(0);
+  const [maxSecondsToKillBoss, setMaxSecondsToKillBoss] = useState(5);
+  const [monsterCount, setMonsterCount] = useState(1);
   const [maxMonsterCount, setMaxMonsterCount] = useState(10);
-  const [countdown, setCountdown] = useState(30);
+  const [countdown, setCountdown] = useState(maxSecondsToKillBoss);
   const [beforeBossLife, setBeforeBossLife] = useState(0);
-  const displayCountdown = () => {
-    const intervalId = setInterval(() => {
-      setCountdown(countdown - 1);
-    }, 1000);
-    if (countdown === 0) {
-      clearInterval(intervalId);
-    }
-  };
 
-  const bossTimer = () => {
-    const timeoutId = setTimeout(() => {
-      setMaxLife(beforeBossLife);
-      setMonsterZone(monsterZone - 1);
-      setMonsterCount(0);
-      setMaxMonsterCount(10);
-    }, 2000);
-    if (countdown === 0) {
-      clearTimeout(timeoutId);
-    }
-  };
   const spawnMonster = () => {
-    if (monsterCount === maxMonsterCount - 1) {
+    if (monsterCount === maxMonsterCount) {
+      setMonsterCount(1);
       if (monsterZone % 9 === 0) {
         setBeforeBossLife(maxLife);
         setMaxLife((maxLife = Math.round(maxLife * 60)));
-        setMonsterCount(0);
         setMaxMonsterCount(1);
         setMonsterZone(monsterZone + 1);
       } else {
@@ -48,7 +30,6 @@ export default function Zones({
           setMaxLife((maxLife = Math.round(maxLife / 30)));
         }
         setMaxLife((maxLife = Math.round(maxLife * 1.8)));
-        setMonsterCount(0);
         setMonsterZone(monsterZone + 1);
         setMaxMonsterCount(10);
       }
@@ -56,9 +37,19 @@ export default function Zones({
     setLife((life = maxLife));
   };
   useEffect(() => {
-    if (monsterZone % 10 === 0) {
-      displayCountdown();
-      bossTimer();
+    if (monsterZone % 10 === 0 && countdown === maxSecondsToKillBoss && life === maxLife) {
+      for (let i = 0; i < maxSecondsToKillBoss; i++) {
+        setTimeout(() => {
+          setCountdown(countdown - (i + 1))
+        }, 1000 * (i + 1))
+      }
+    }
+    if (countdown <= 0 && monsterZone % 10 === 0) { // If still against the boss when timer is done
+      setMaxLife(beforeBossLife);
+      setLife(beforeBossLife);
+      setCountdown(maxSecondsToKillBoss)
+      setMonsterZone(monsterZone - 1);
+      setMaxMonsterCount(10);
     }
     if (life <= 0) {
       setScore(score + maxLife / 6);


### PR DESCRIPTION
Issue seems to have been one or two timers being triggered multiple times during the same (boss)fight through useEffect, which was making things... wacky
I've also changed monsterCount so first monster is 1/10 and last monster is 10/10 (used to be 0/10 and 9/10 respectively)

I might've forgotten to change back the time to take down a boss from 5 to 30, but it's not like we're currently making things balanced anyway lol