### PR TITLE
Fix bosses being broken starting from 2nd boss

### DIFF
--- a/src/components/Zones.jsx
+++ b/src/components/Zones.jsx
@@ -20,7 +20,7 @@ export default function Zones({
   const spawnMonster = () => {
     if (monsterCount === maxMonsterCount) {
       setMonsterCount(1);
-      if (monsterZone % 9 === 0) {
+      if ((monsterZone + 1) % 10 === 0) {
         setBeforeBossLife(maxLife);
         setMaxLife((maxLife = Math.round(maxLife * 10)));
         setMaxMonsterCount(1);


### PR DESCRIPTION
yes, it was a single line change
Without this line change, things get kinda wacky as the block gets triggered on zone 18, 27, 36, etc...
Went unnoticed as it triggers correctly on zone 9