### PR TITLE
Fix jobs failing when PR is made

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,8 +6,6 @@ name: Node.js CI
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
Quite the oversight on my end
The job is made to deploy the main branch on GitHub Pages, but it was also trying to deploy the branches that are PRed to main on the same place, which is not possible for security reasons and would not make sense anyway

With this PR, PRs will not trigger the job that deploys to GitHub Pages anymore
I'm sure you could add a separate job that checks if PRs can be built properly if you wanted though, but for such a project, I don't think it's worth looking into unless you wanna get familiar with GitHub Actions