### PR TITLE
Add countdown to potion

### DIFF
--- a/src/components/Potion.jsx
+++ b/src/components/Potion.jsx
@@ -7,20 +7,39 @@ export default function Potion({
   setExperience,
 }) {
   const [price, setPrice] = useState(100000);
+  let [length, setLength] = useState(75);
 
   const buyPotion = () => {
-    setPotion(true);
-    setTimeout(() => {
-      setPotion(false);
-    }, 15 * 60 * 1000);
+    if (!potion) {
+      let countdown = setInterval(() => setLength((length) => length - 1), 1000)
+      setPotion(true);
+      setTimeout(() => {
+        setPotion(false);
+        clearInterval(countdown);
+        setLength(length); // Because it's in timeout, length is the original value
+      }, length * 1000);
+    }
   };
 
   return (
     <>
-      {potion && <p>You currently are under effect of a potion!</p>}
+      {potion && <p>The potion's effects will dissipate in {getLengthInWrittenForm(length)}</p>}
       <button type="button" onClick={() => buyPotion()}>
-        Buy potion : {Math.round(price)} points
+        Buy potion: {Math.round(price)} points
       </button>
     </>
   );
+}
+
+function getLengthInWrittenForm(length) {
+  let minutes = 0;
+  let seconds = 0;
+  for (let i = length; i >= 60; i -= 60) {
+    minutes++;
+    length -= 60
+  };
+  for (let i = 0; i < length; i++) {
+    seconds++;
+  };
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }


### PR DESCRIPTION
Nothing too crazy in this PR, it prevents players from buying the potion while the potion is already active and adds a countdown that tells the player when the potion will become inactive (and when they'll be able to buy a potion again) in the form of mm:ss