### PR TITLE
Move HP counter to middle of HP bar

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -124,8 +124,10 @@ export default function Game() {
             setMonsterZone={setMonsterZone}
           />
         </div>
-        <progress max={maxLife} value={life} className="healthbar" />
-        <p>{life} HP</p>
+        <div className="health">
+          <progress max={maxLife} value={life} className="healthbar" />
+          <p className="healthcounter">{life} HP</p>
+        </div>
         <p className="score">score : {Math.round(score)}</p>
       </div>
       <footer>

--- a/src/style/progressbar.css
+++ b/src/style/progressbar.css
@@ -1,14 +1,25 @@
-.healthbar {
-  border: none;
-  width: 400px;
-  height: 60px;
-  background: crimson;
+.health {
+  display: inline-flex;
+  width: 100vw;
+  margin: 10px;
+}
+.health * {
+  position: absolute;
+  margin: 0;
+  width: 350px;
+  left: calc(50% - 350px / 2);
+}
+
+.healthcounter {
+  text-align: center;
+  padding-top: 2px;
 }
 
 .healthbar {
+  border: none;
+  background: crimson;
   color: crimson;
   height: 25px;
-  width: 350px;
 }
 
 .healthbar::-moz-progress-bar {


### PR DESCRIPTION
This is the way I personally would prefer showing the HP counter
Putting it next to the HP bar would make things look uncentered
It's also worth considering the fact that the HP counter would have varying width, as the health of monsters can go from 1 digit to a lot more
![image](https://user-images.githubusercontent.com/67872932/211841894-b12f98c4-ce70-44b5-8670-4edba41067a4.png)
