### PR TITLE
Create debug mode

### DIFF
--- a/src/components/Debug.jsx
+++ b/src/components/Debug.jsx
@@ -1,0 +1,60 @@
+import { useEffect } from "react"
+import "../style/debug.css";
+
+// useEffect is triggered 3 times + 1 additional time for each button click on debug menu
+let preventUseEffectShenanigans = 0
+
+export default function Debug({
+  setPower,
+  setScore,
+  setExperience,
+  setMonsterZone
+}) {
+  useEffect(() => {
+    if (preventUseEffectShenanigans > 0) return
+    preventUseEffectShenanigans++
+
+    let keyPressed = {};
+    let debugMenu = document.getElementsByClassName("debugMenu")[0]
+
+    const keydown = function(e) {
+      keyPressed[e.key + e.location] = true;
+      if (keyPressed.Shift1 == true && keyPressed.Control1 == true) {
+        debugMenu.style.display = debugMenu.style.display === "none" ?
+        "block" : "none";
+        keyPressed = {};
+      }
+    }
+    const keyup = function(e) {
+      keyPressed[e.key + e.location] = false;
+      keyPressed = {};
+    }
+
+    document.addEventListener("keydown", keydown);
+    document.addEventListener("keyup", keyup);
+  })
+  return (
+    <div className="debugMenu" style={{display: "none"}}>
+      <div className="debugOption">
+        Power:
+        <input className="debugPower"></input>
+        <button onClick={() => setPower(Number(document.getElementsByClassName("debugPower")[0].value))}>Set</button>
+      </div>
+      <div className="debugOption">
+        Score:
+        <input className="debugScore"></input>
+        <button onClick={() => setScore(Number(document.getElementsByClassName("debugScore")[0].value))}>Set</button>
+      </div>
+      <div className="debugOption">
+        Experience:
+        <input className="debugExp"></input>
+        <button onClick={() => setExperience(Number(document.getElementsByClassName("debugExp")[0].value))}>Set</button>
+      </div>
+      <div className="debugOption">
+        Zone:
+        <input className="debugZone"></input>
+        <button onClick={() => setMonsterZone(Number(document.getElementsByClassName("debugZone")[0].value))}>Set</button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Debug.jsx
+++ b/src/components/Debug.jsx
@@ -19,7 +19,7 @@ export default function Debug({
 
     const keydown = function(e) {
       keyPressed[e.key + e.location] = true;
-      if (keyPressed.Shift1 == true && keyPressed.Control1 == true) {
+      if (keyPressed.Control1 == true && keyPressed.Control2 == true) {
         debugMenu.style.display = debugMenu.style.display === "none" ?
         "block" : "none";
         keyPressed = {};

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -10,6 +10,7 @@ import Zones from "./Zones";
 import Debug from "./Debug";
 
 export default function Game() {
+  const allowDebug = false;
   const [potion, setPotion] = useState(false);
   const [blobClicked, setBlobClicked] = useState(false);
   let [power, setPower] = useState(1);
@@ -70,12 +71,14 @@ export default function Game() {
   };
   return (
     <>
-      <Debug
-        setPower={setPower}
-        setScore={setScore}
-        setExperience={setExperience}
-        setMonsterZone={setMonsterZone}
-      />
+      {allowDebug === true && (
+        <Debug
+          setPower={setPower}
+          setScore={setScore}
+          setExperience={setExperience}
+          setMonsterZone={setMonsterZone}
+        />
+      )}
       <div className="gameContainer">
         <Experiencebar
           setExperience={setExperience}

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -7,6 +7,7 @@ import target from "../../assets/target.png";
 import Shop from "./Shop";
 import Experiencebar from "./Experiencebar";
 import Zones from "./Zones";
+import Debug from "./Debug";
 
 export default function Game() {
   const [potion, setPotion] = useState(false);
@@ -69,6 +70,12 @@ export default function Game() {
   };
   return (
     <>
+      <Debug
+        setPower={setPower}
+        setScore={setScore}
+        setExperience={setExperience}
+        setMonsterZone={setMonsterZone}
+      />
       <div className="gameContainer">
         <Experiencebar
           setExperience={setExperience}

--- a/src/style/debug.css
+++ b/src/style/debug.css
@@ -1,0 +1,26 @@
+.debugMenu {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 40em;
+  height: 18em;
+  margin-top: -9em; /*set to a negative number 1/2 of height*/
+  margin-left: -20em; /*set to a negative number 1/2 of width*/
+  border: 2px solid white;
+  border-radius: 20px;
+  background-color: black;
+  z-index: 1;
+  text-align: center;
+}
+
+.debugOption {
+  margin: 2px;
+}
+
+.debugOption * {
+  color: black;
+}
+
+.debugOption input {
+  width: 75px;
+}


### PR DESCRIPTION
You did not ask for it, yet here it is anyway
This PR adds a debug menu, which allows you to modify values while in-game
Its purpose is so you (or I) no longer need to make changes such as [d45e8bb](https://github.com/RemiL-Nel/Clicker-game/commit/d45e8bb38825f621ae57bb8dad9c4ac87a5e3bd5)

Obviously, this menu is not meant to be used by the average player, and may only be opened and closed by using specific keybinds (here, it's leftcontrol + rightcontrol)
Because of that, this is something we don't **need** to update frequently, as it's just what I believe to be a nice bonus that can help with development

Note that there's now a variable called `allowDebug`, which, when set to false (as it is with this PR), prevents the menu from appearing
That way, disallowing your average player from opening the menu is gonna be piss easy

https://user-images.githubusercontent.com/67872932/215001048-72c1b6fd-33b5-48fe-9f40-ce7a4948be0b.mp4

