### PR TITLE
Fix two bugs with enchants

### DIFF
--- a/src/components/Enchants.jsx
+++ b/src/components/Enchants.jsx
@@ -1,10 +1,48 @@
 import "../style/shop.css";
 
 export default function Enchants({
+  score,
+  setScore,
+  swords,
+  setSwords,
+  makeSwordDealDamage,
+  intervalId,
+  clearInterval,
   enchantsPrice,
-  handleBuyEnchant,
-  swords
+  setEnchantsPrice
 }) {
+  const handleBuyEnchant = (selectedSword) => {
+    if (score >= Math.round(enchantsPrice)) {
+      setScore(score - Math.round(enchantsPrice));
+      setEnchantsPrice(enchantsPrice * 1.2);
+      const updatedSwords = swords.map((s) => {
+        if (s.id === parseInt(selectedSword)) {
+          s.enchant = Math.floor(Math.random() * 1000);
+          if (s.enchant === 727) {
+            alert("Legendary Enchant: WYSI! Damage of this sword +727%");
+            if (s.equipped) {
+              clearInterval(intervalId);
+              makeSwordDealDamage({ ...s, damage: Math.round(s.damage * 8.27) });
+            }
+            return { ...s, damage: Math.round(s.damage * 1.1) };
+          } else if (s.enchant > 500) {
+            alert("Common enchant: Damage of this sword +10%!");
+            if (s.equipped) {
+              clearInterval(intervalId);
+              makeSwordDealDamage({ ...s, damage: Math.round(s.damage * 1.1) });
+            }
+            return { ...s, damage: Math.round(s.damage * 1.1) };
+          } else if (s.enchant <= 500) {
+            alert("Common enchant: Price of this sword -50%!");
+            return { ...s, price: Math.round(s.price * 0.5) };
+          }
+        }
+        return s;
+      });
+      setSwords(updatedSwords);
+    }
+  };
+
   const swordsToEnchant = swords.filter((s) => s.bought && s.enchant < 1)
   return (
     <div className="enchantsTab">

--- a/src/components/Enchants.jsx
+++ b/src/components/Enchants.jsx
@@ -22,16 +22,16 @@ export default function Enchants({
             alert("Legendary Enchant: WYSI! Damage of this sword +727%");
             if (s.equipped) {
               clearInterval(intervalId);
-              makeSwordDealDamage({ ...s, damage: Math.round(s.damage * 8.27) });
+              makeSwordDealDamage({ ...s, damage: s.damage * 8.27 });
             }
-            return { ...s, damage: Math.round(s.damage * 1.1) };
+            return { ...s, damage: s.damage * 8.27 };
           } else if (s.enchant > 500) {
             alert("Common enchant: Damage of this sword +10%!");
             if (s.equipped) {
               clearInterval(intervalId);
-              makeSwordDealDamage({ ...s, damage: Math.round(s.damage * 1.1) });
+              makeSwordDealDamage({ ...s, damage: s.damage * 1.1 });
             }
-            return { ...s, damage: Math.round(s.damage * 1.1) };
+            return { ...s, damage: s.damage * 1.1 };
           } else if (s.enchant <= 500) {
             alert("Common enchant: Price of this sword -50%!");
             return { ...s, price: Math.round(s.price * 0.5) };

--- a/src/components/Shop.jsx
+++ b/src/components/Shop.jsx
@@ -179,37 +179,6 @@ export default function Shop({
       },
     },
   ]);
-  const handleBuyEnchant = (selectedSword) => {
-    if (score >= Math.round(enchantsPrice)) {
-      setScore(score - Math.round(enchantsPrice));
-      setEnchantsPrice(enchantsPrice * 1.2);
-      const updatedSwords = swords.map((s) => {
-        if (s.id === parseInt(selectedSword)) {
-          s.enchant = Math.floor(Math.random() * 1000);
-        }
-        if (s.enchant === 727) {
-          alert("Legendary Enchant : WYSI ! Damage of this sword +727%");
-          if (s.equipped) {
-            clearInterval(intervalId);
-            makeSwordDealDamage({ ...s, damage: Math.round(s.damage * 8.27) });
-          }
-          return { ...s, damage: Math.round(s.damage * 1.1) };
-        } else if (s.enchant > 500) {
-          alert("Common enchant : Damage of this sword +10% !");
-          if (s.equipped) {
-            clearInterval(intervalId);
-            makeSwordDealDamage({ ...s, damage: Math.round(s.damage * 1.1) });
-          }
-          return { ...s, damage: Math.round(s.damage * 1.1) };
-        } else if (s.enchant <= 500) {
-          alert("Common enchant : Price of this sword -50% !");
-          return { ...s, price: Math.round(s.price * 0.5) };
-        }
-        return s;
-      });
-      setSwords(updatedSwords);
-    }
-  };
 
   const handleBuyScroll = (scroll) => {
     if (score >= Math.round(scroll.price)) {
@@ -432,10 +401,15 @@ export default function Shop({
           ))}
         {currentTab === 3 && (
           <Enchants
+            score={score}
+            setScore={setScore}
             swords={swords}
             setSwords={setSwords}
+            makeSwordDealDamage={makeSwordDealDamage}
+            intervalId={intervalId}
+            clearInterval={clearInterval}
             enchantsPrice={enchantsPrice}
-            handleBuyEnchant={handleBuyEnchant}
+            setEnchantsPrice={setEnchantsPrice}
           />
         )}
       </div>


### PR DESCRIPTION
The code for enchanting used to be executed for each sword, leading notably to getting several alerts (one per sword) when enchanting a sword
The code for buffing a sword used to sometimes debuff the sword due to the rounding; for example, enchanting a wooden stick (0.2 dmg) would change its damage to 0
If you still want rounding (although that would not make sense given the current sword damage), you might wanna use Math.ceil() over Math.round()