### PR TITLE
Fix boss targets being grabbable

### DIFF
--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -127,11 +127,14 @@ export default function Game() {
               <img
                 src={target}
                 alt="random"
+                draggable="false"
+                onDragStart={() => {return false}}
                 style={{
                   width: "50px",
                   position: "absolute",
                   left: imagePosition.x,
                   top: imagePosition.y,
+                  MozUserSelect: "none",
                 }}
               />
             </button>


### PR DESCRIPTION
Works on Firefox
Untested on Chromium-based browsers